### PR TITLE
fixed issue that parameter order was not respected when copying from train to val model

### DIFF
--- a/src/mlham/kernel.jl
+++ b/src/mlham/kernel.jl
@@ -169,6 +169,19 @@ Retrieve the parameters associated with a `HamiltonianKernel`.
 get_params(kernel::HamiltonianKernel) = kernel.params
 
 """
+    copy_params!(receiving_model::HamiltonianKernel, sending_model::HamiltonianKernel) -> Nothing
+
+Copy parameters from one Hamiltonian kernel to another.
+
+# Arguments
+- `receiving_model::HamiltonianKernel`: The kernel that will receive the parameters.
+- `sending_model::HamiltonianKernel`: The kernel providing the parameters.
+"""
+function copy_params!(receiving_model::HamiltonianKernel, sending_model::HamiltonianKernel)
+    set_params!(receiving_model, get_params(sending_model))
+end
+
+"""
     write_params(kernel::HamiltonianKernel, conf=get_empty_config(); filename=get_ml_filename(conf))
 
 Writes the parameters and configuration settings of a HamiltonianKernel object to a file.

--- a/src/model/eff_ham.jl
+++ b/src/model/eff_ham.jl
@@ -149,7 +149,7 @@ Copy parameters from one EffectiveHamiltonian (`sending_ham`) to another (`recei
 """
 function copy_params!(receiving_ham::H1, sending_ham::H2) where {H1,H2<:EffectiveHamiltonian}
     for (receiving_model, sending_model) in zip(receiving_ham.models, sending_ham.models) 
-        set_params!(receiving_model, get_params(sending_model))
+        copy_params!(receiving_model, sending_model)
     end
 end
 

--- a/src/model/model.jl
+++ b/src/model/model.jl
@@ -277,3 +277,22 @@ function set_params!(model::TBModel, params)
         model.params = params
     end
 end
+
+"""
+    copy_params!(receiving_model::TBModel, sending_model::TBModel) -> Nothing
+
+Copy matching parameters from one TB model to another.
+
+# Arguments
+- `receiving_model::TBModel`: The model whose parameters will be updated.
+- `sending_model::TBModel`: The model providing parameter values.
+"""
+function copy_params!(receiving_model::TBModel, sending_model::TBModel)
+    for (i, sending_label) in enumerate(sending_model.param_labels)
+        for (j, receiving_label) in enumerate(receiving_model.param_labels)
+            if sending_label == receiving_label
+                receiving_model.params[j] = sending_model.params[i]
+            end
+        end
+    end
+end

--- a/src/optim/optimize.jl
+++ b/src/optim/optimize.jl
@@ -172,11 +172,10 @@ function val_step!(ham_val, loss, val_data, prof, iter, comm; rank=0, nranks=1, 
     
     val_time_local = MPI.Wtime() - val_begin
     val_time = MPI.Reduce(val_time_local, +, comm, root=0)
-    Nstrc_tot = MPI.Reduce(length(Ls_val), +, comm, root=0)
     L_val = MPI.Reduce(sum(Ls_val), +, comm, root=0)
     if rank == 0
         prof.val_times[iter] = val_time ./ nranks
-        prof.L_val[iter-valeachiter+1:iter] .= L_val ./ Nstrc_tot
+        prof.L_val[iter-valeachiter+1:iter] .= L_val ./ nranks
     end
 end
 

--- a/src/optim/optimize.jl
+++ b/src/optim/optimize.jl
@@ -169,13 +169,14 @@ function val_step!(ham_val, loss, val_data, prof, iter, comm; rank=0, nranks=1, 
             prof.L_val_system[system][iter] = mean(loss_system)
         end
     end
-
+    
     val_time_local = MPI.Wtime() - val_begin
     val_time = MPI.Reduce(val_time_local, +, comm, root=0)
+    Nstrc_tot = MPI.Reduce(length(Ls_val), +, comm, root=0)
     L_val = MPI.Reduce(sum(Ls_val), +, comm, root=0)
     if rank == 0
         prof.val_times[iter] = val_time ./ nranks
-        prof.L_val[iter-valeachiter+1:iter] .= L_val ./ nranks
+        prof.L_val[iter-valeachiter+1:iter] .= L_val ./ Nstrc_tot
     end
 end
 

--- a/src/soc/soc_model.jl
+++ b/src/soc/soc_model.jl
@@ -199,6 +199,25 @@ function set_params!(soc_model::SOCModel, params)
 end
 
 """
+    copy_params!(receiving_model::SOCModel, sending_model::SOCModel) -> Nothing
+
+Copy matching parameters from one SOC model to another.
+
+# Arguments
+- `receiving_model::SOCModel`: The model whose parameters will be updated.
+- `sending_model::SOCModel`: The model providing parameter values.
+"""
+function copy_params!(receiving_model::SOCModel, sending_model::SOCModel)
+    for (i, sending_label) in enumerate(sending_model.param_labels)
+        for (j, receiving_label) in enumerate(receiving_model.param_labels)
+            if sending_label == receiving_label
+                receiving_model.params[j] = sending_model.params[i]
+            end
+        end
+    end
+end
+
+"""
     write_params(soc_model::SOCModel, conf=get_empty_config()) -> Nothing
 
 Writes the parameters of a spin-orbit coupling (SOC) model to a file.


### PR DESCRIPTION
When copying parameters from the training to the validation model, the parameter order may differ, e.g., if the atom order is different in the POSCAR. This led to unexpected behavior. To fix this, the `copy_params!` now dispatches on each model type and respects parameter order if necessary.